### PR TITLE
test websocket close frame

### DIFF
--- a/tests/utils/frame.py
+++ b/tests/utils/frame.py
@@ -39,7 +39,13 @@ class FrameTest(unittest.TestCase):
         f = parser.pong()
         self.assertEqual(f.opcode, 0xA)
         self.assertTrue(f.payload_length <= 125)
-        
+
+    def testCloseFrame(self):
+        close_message = struct.pack('!H', 1000) + b'OK'
+        f = Frame(close_message, opcode=0x8)
+        self.assertTrue(f.is_close)
+        self.assertEqual(close_message, f.msg[2:])
+
     def testUnmaskedDataFrame(self):
         parser = FrameParser(kind=2)
         f = parser.encode('Hello')


### PR DESCRIPTION
Simple test. Issue #59 
There are maybe some ideas what else should we test?

Also, I think we should look at https://github.com/aaugustin/websockets/blob/master/websockets/framing.py
and maybe implement same close frames parsing
