### PR TITLE
Bind `connection_made` event in `Connection`

### DIFF
--- a/examples/echo/manage.py
+++ b/examples/echo/manage.py
@@ -131,6 +131,7 @@ class EchoProtocol(pulsar.ProtocolConsumer):
     def connection_lost(self, connection):
         self.logger.info("Disconnected from {}".format(connection))
 
+
 class EchoServerProtocol(EchoProtocol):
     '''The :class:`EchoProtocol` used by the echo :func:`server`.
     '''

--- a/examples/echo/manage.py
+++ b/examples/echo/manage.py
@@ -91,6 +91,9 @@ class EchoProtocol(pulsar.ProtocolConsumer):
     buffer = b''
     '''The buffer for long messages'''
 
+    def connection_made(self, connection):
+        self.logger.info("Connected from {}".format(connection))
+
     def data_received(self, data):
         '''Implements the :meth:`~.ProtocolConsumer.data_received` method.
 
@@ -125,6 +128,8 @@ class EchoProtocol(pulsar.ProtocolConsumer):
             raise ProtocolError
         return data[:-len(self.separator)]
 
+    def connection_lost(self, connection):
+        self.logger.info("Disconnected from {}".format(connection))
 
 class EchoServerProtocol(EchoProtocol):
     '''The :class:`EchoProtocol` used by the echo :func:`server`.
@@ -214,11 +219,5 @@ def server(name=None, description=None, **kwargs):
     return SocketServer(EchoServerProtocol, name=name,
                         description=description, **kwargs)
 
-
-def log_connection(connection, exc=None):
-    if not exc:
-        connection.logger.info('Got a new connection!')
-
-
 if __name__ == '__main__':  # pragma nocover
-    server(connection_made=log_connection).start()
+    server().start()

--- a/pulsar/async/protocols.py
+++ b/pulsar/async/protocols.py
@@ -448,7 +448,7 @@ class Connection(Protocol, Timeout):
             consumer = self._producer.build_consumer(self._consumer_factory)
             assert self._current_consumer is None, 'Consumer is not None'
             self._current_consumer = consumer
-            self._current_consumer._connection = self 
+            self._current_consumer._connection = self
 
     def _connection_lost(self, _, exc=None):
         '''It performs these actions in the following order:

--- a/pulsar/async/protocols.py
+++ b/pulsar/async/protocols.py
@@ -463,7 +463,7 @@ class Connection(Protocol, Timeout):
             self._current_consumer.connection_lost(self)
 
     def _connection_made(self, _, exc=None):
-        '''Handler connection_made event in ProtocolConsumer 
+        '''Handler connection_made event in ProtocolConsumer
            or in its subclass'''
 
         self.current_consumer()

--- a/pulsar/async/protocols.py
+++ b/pulsar/async/protocols.py
@@ -463,7 +463,8 @@ class Connection(Protocol, Timeout):
             self._current_consumer.connection_lost(self)
 
     def _connection_made(self, _, exc=None):
-        '''Handler connection_made event in ProtocolConsumer or in its subclass'''
+        '''Handler connection_made event in ProtocolConsumer 
+           or in its subclass'''
 
         self.current_consumer()
         if self._current_consumer:


### PR DESCRIPTION
Bind `connection_made` event in `Connection`, so  you can handler `connection_made` event in `ProtocolConsumer` or in its subclass by override `connection_made` method.