### PR TITLE
Set wsgi.input to BytesIO before some of the parsers will fail

### DIFF
--- a/pulsar/apps/wsgi/wrappers.py
+++ b/pulsar/apps/wsgi/wrappers.py
@@ -552,14 +552,13 @@ class WsgiRequest(EnvironMixin):
         if chunk is not None:
             content_type, options = self.content_type_options
             charset = options.get('charset', 'utf-8')
+            self.environ['wsgi.input'] = BytesIO(chunk)
             if content_type in JSON_CONTENT_TYPES:
                 result = json.loads(chunk.decode(charset)), None
             elif content_type:
-                self.environ['wsgi.input'] = BytesIO(chunk)
                 result = parse_form_data(self.environ, charset)
             else:
                 result = chunk, None
-            self.environ['wsgi.input'] = BytesIO(chunk)
         self.cache.data_and_files = result
         return self.data_and_files(data, files)
 


### PR DESCRIPTION
This change gives possible to get raw input data from WsgiRequest if some of parsers (used for application/json or form content type) fails due to format error. This is useful for logging, for example.