### PR TITLE
StopIteration problem

### DIFF
--- a/pulsar/apps/greenio/__init__.py
+++ b/pulsar/apps/greenio/__init__.py
@@ -300,7 +300,10 @@ class GreenPool(AsyncObject):
             if task:
                 future, func, args, kwargs = task
                 try:
-                    result = func(*args, **kwargs)
+                    try:
+                        result = func(*args, **kwargs)
+                    except StopIteration as exc:  # See PEP 479
+                        raise RuntimeError('Unhandled StopIteration') from exc
                 except Exception as exc:
                     future.set_exception(exc)
                 else:

--- a/tests/apps/greenio.py
+++ b/tests/apps/greenio.py
@@ -142,3 +142,9 @@ class TestGreenIO(unittest.TestCase):
         green = GreenWSGI(wsgi, pool)
         self.assertEqual(green.wsgi, wsgi)
         self.assertEqual(green.pool, pool)
+
+    def test_uncatched_stopiteration(self):
+        pool = greenio.GreenPool()
+        with self.assertRaises(RuntimeError) as cm:
+            yield from pool.submit(lambda: next(iter([])))
+        self.assertIsInstance(cm.exception.__cause__, StopIteration)


### PR DESCRIPTION
This demonstrates the problem when StopIteration is raised in a task but not catched, the solution is not great and needs some discussion.

How to reproduce the error (cause by a mistake in a test):
Make a task (pulsar-queue) which raises a StopIteration exception.
The task will finish as Successful, probably because StopIteration is also seen as the end of a coroutine.