### PR TITLE
Allow per request proxy tuple to be set; also don't mangle CONNECT request url

### DIFF
--- a/pulsar/apps/http/__init__.py
+++ b/pulsar/apps/http/__init__.py
@@ -548,11 +548,14 @@ class HttpRequest(RequestBase):
         self._data = self._encode_data(data)
 
     def first_line(self):
-        if not self._proxy and self.method != self.CONNECT:
+        if self._proxy:
+            if self.method == self.CONNECT:
+                url = self._netloc
+            else:
+                url = self.full_url
+        else:
             url = urlunparse(('', '', self.path or '/', self.params,
                               self.query, self.fragment))
-        else:
-            url = self.full_url
         return '%s %s %s' % (self.method, url, self.version)
 
     def new_parser(self):

--- a/pulsar/apps/http/__init__.py
+++ b/pulsar/apps/http/__init__.py
@@ -440,6 +440,7 @@ class HttpRequest(RequestBase):
                  source_address=None, allow_redirects=False, max_redirects=10,
                  decompress=True, version=None, wait_continue=False,
                  websocket_handler=None, cookies=None, urlparams=None,
+                 proxy_tuple=None,
                  **ignored):
         self.client = client
         self._data = None
@@ -477,7 +478,11 @@ class HttpRequest(RequestBase):
             cookies.add_cookie_header(self)
         self.unredirected_headers['host'] = host_no_default_port(self._scheme,
                                                                  self._netloc)
-        client.set_proxy(self)
+        if proxy_tuple:
+            self.set_proxy(*proxy_tuple)
+        else:
+            client.set_proxy(self)
+
         self.data = data
 
     @property


### PR DESCRIPTION
Hi, I've been evaluating using pulsar for a project of mine, love the asynchronous WSGI server support. Kudos!

I do however need to set a proxy per request while maintaining a connection pool, so I modified HttpRequest to allow for a proxy_tuple to be specified. There's probably a better way to do accomplish this, if there is please let me know.

I also found that the first line of CONNECT requests was being set to the full URL, which caused my upstream proxy to freak out; I've added that commit into here as well.

Quick question as well, on pulsar.apps.wsgi.server:460 it appears the full status line is simply hard coded to allow for tunneled requests to not be marked as chunked? It bit me rather hard so I'm wondering if there's a better way we could accomplish that check.

Ty!
Trevor