### PR TITLE
Fix params initial bug in MutiApp

### DIFF
--- a/pulsar/apps/__init__.py
+++ b/pulsar/apps/__init__.py
@@ -589,7 +589,7 @@ class MultiApp(Configurator):
             apps = self._apps
             self._apps = []
             for App, name, callable, cfg in self._iter_app(apps):
-                settings = self.cfg.settings
+                settings = cfg.settings.copy()
                 new_settings = {}
                 for key in cfg:
                     setting = settings[key].copy()


### PR DESCRIPTION
i use example.flaskgreen.manage for me, 

```

def log_connection(connection, exc=None):
    if not exc:
       connection.logger.info('Got a new connection!')

class Servers(MultiApp):
    """Multiapp Server configurator
    """
    cfg = Config(bind=':8080', echo_bind=':8060')

    def build(self):
        yield self.new_app(WSGIServer, callable=FlaskSite())
        yield self.new_app(SocketServer, 'echo', callable=EchoServerProtocol, connect_made=log_connection)
```
the callback function is not called, and i find this bug and fix it ,it`s work fine.