### PR TITLE
always decode content as json in JsonProxy

### DIFF
--- a/pulsar/apps/http/__init__.py
+++ b/pulsar/apps/http/__init__.py
@@ -644,6 +644,11 @@ class HttpResponse(ProtocolConsumer):
         """
         data = self.content
         if data is not None:
+            if charset is None:
+                ct = self.headers.get('content-type')
+                if ct:
+                    ct, options = parse_options_header(ct)
+                    charset = options.get('charset')
             return data.decode(charset or 'utf-8', errors or 'strict')
     content_string = text
 

--- a/pulsar/apps/rpc/jsonrpc.py
+++ b/pulsar/apps/rpc/jsonrpc.py
@@ -243,7 +243,7 @@ class JsonProxy(AsyncObject):
         if self._full_response:
             return resp
         else:
-            content = resp.decode_content()
+            content = resp.json()
             if resp.is_error:
                 if 'error' not in content:
                     resp.raise_for_status()
@@ -343,7 +343,7 @@ class JsonBatchProxy(JsonProxy):
             self.discard()
             return resp
         else:
-            content = resp.decode_content()
+            content = resp.json()
             if resp.is_error:
                 if 'error' not in content:
                     resp.raise_for_status()


### PR DESCRIPTION
As discussed in #232.

In order to still get the charset from the http header I produced some duplicated code...