### PR TITLE
Fix: handle HEAD method empty response on errors like 404

### DIFF
--- a/pulsar/utils/httpurl.py
+++ b/pulsar/utils/httpurl.py
@@ -1019,7 +1019,7 @@ class HttpParser:
         return len(rest)
 
     def _parse_body(self):
-        if not self._clen_rest:  # return "Already parsed" for empty response
+        if not self._clen_rest and has_empty_content(self._status_code, self._method):  # return "Already parsed" for empty response
             return 0
 
         data = b''.join(self._buf)

--- a/pulsar/utils/httpurl.py
+++ b/pulsar/utils/httpurl.py
@@ -1019,6 +1019,9 @@ class HttpParser:
         return len(rest)
 
     def _parse_body(self):
+        if self._clen_rest <= 0:  # return "Already parsed" for empty response
+            return 0
+
         data = b''.join(self._buf)
         #
         if not self._chunked:

--- a/pulsar/utils/httpurl.py
+++ b/pulsar/utils/httpurl.py
@@ -1019,7 +1019,7 @@ class HttpParser:
         return len(rest)
 
     def _parse_body(self):
-        if not self._clen_rest and has_empty_content(self._status_code, self._method):  # return "Already parsed" for empty response
+        if not self._clen_rest and self._method.upper() == 'HEAD':  # return "Already parsed" for empty response on HEAD method
             return 0
 
         data = b''.join(self._buf)

--- a/pulsar/utils/httpurl.py
+++ b/pulsar/utils/httpurl.py
@@ -1019,7 +1019,7 @@ class HttpParser:
         return len(rest)
 
     def _parse_body(self):
-        if self._clen_rest <= 0 and self._clen <= 0:  # return "Already parsed" for empty response
+        if not self._clen_rest:  # return "Already parsed" for empty response
             return 0
 
         data = b''.join(self._buf)

--- a/pulsar/utils/httpurl.py
+++ b/pulsar/utils/httpurl.py
@@ -1019,7 +1019,8 @@ class HttpParser:
         return len(rest)
 
     def _parse_body(self):
-        if not self._clen_rest and self._method.upper() == 'HEAD':  # return "Already parsed" for empty response on HEAD method
+        # return "Already parsed" for empty response on HEAD method
+        if not self._clen_rest and self._method.upper() == 'HEAD':
             return 0
 
         data = b''.join(self._buf)

--- a/pulsar/utils/httpurl.py
+++ b/pulsar/utils/httpurl.py
@@ -1019,7 +1019,7 @@ class HttpParser:
         return len(rest)
 
     def _parse_body(self):
-        if self._clen_rest <= 0:  # return "Already parsed" for empty response
+        if self._clen_rest <= 0 and self._clen <= 0:  # return "Already parsed" for empty response
             return 0
 
         data = b''.join(self._buf)


### PR DESCRIPTION
I've noticed that if you're using pulsar-cloud with its Asyncbotocore, you can sometimes experience infinite waiting. This happens when you try to call things like:
`
from cloud.aws import AsyncioBotocore  
self._s3 = AsyncioBotocore('s3', aws_region, aws_access_key_id=aws_access_key_id,
                                       aws_secret_access_key=aws_secret_access_key)  
self._obj_head = await self._s3.head_object(Bucket=self._aws_bucket, Key=guid)
`
So, you try to make HEAD on non-exisent guid. S3 returns a "chunked" response with code 404. But the request method was HEAD, so the response body is empty. Nevertheless the whole application hangs awaiting for some data to be received and never returns.
After some investigation and looking closely at pulsar/utils/httpurl.py I noticed that _parse_headers method checks for `has_empty_content(status, self._method)` and sets `self._clen_rest = self._clen = clen` correctly, but _parse_body doesn't handle chunked empty response correctly. So, I made this patch and now it works for me. What do you think: is this solution correct?