### PR TITLE
Fix: type for HTTP Keepalive param

### DIFF
--- a/pulsar/utils/config.py
+++ b/pulsar/utils/config.py
@@ -803,6 +803,7 @@ class HttpKeepAlive(Global):
     name = "http_keep_alive"
     flags = ["--http-keep-alive"]
     default = 70
+    type = int
     desc = """\
         Keep HTTP connections alive for this number of seconds
         """


### PR DESCRIPTION
When running pulsar apps with --http-keep-alive param specified like that:
`python run.py --timeout 120 --keep-alive 120 --http-keep-alive 120 `
We get the following errors:
`ERROR 17:30:29 pulsar.wsgi.worker events.py:79 Exception while firing data_processed: [<bound method Timeout._add_timeout of X.X.X.X:443 session 2>]
Traceback (most recent call last):
File "/opt/venv/xxx/src/pulsar/pulsar/async/events.py", line 77, in fire
hnd(arg, *kwargs)
File "/opt/venv/xxx/src/pulsar/pulsar/async/mixins.py", line 105, in _add_timeout
self._timed_out)
File "/usr/lib/python3.5/asyncio/base_events.py", line 462, in call_later
timer = self.call_at(self.time() + delay, callback, args)
TypeError: unsupported operand type(s) for +: 'float' and 'str'`

This happens due to the absence of type specified for HttpKeepAlive param. Pull request specified fixes the issue