### PR TITLE
No dump cookies for security reasons

### DIFF
--- a/pulsar/apps/wsgi/utils.py
+++ b/pulsar/apps/wsgi/utils.py
@@ -209,6 +209,7 @@ error_messages = {
 
 class dump_environ:
     __slots__ = ('environ',)
+    FILTERED_KEYS = ['HTTP_COOKIE']
 
     def __init__(self, environ):
         self.environ = environ
@@ -216,6 +217,8 @@ class dump_environ:
     def __str__(self):
         def _():
             for k, v in self.environ.items():
+                if k in self.FILTERED_KEYS:
+                    continue
                 try:
                     v = str(v)
                 except Exception as e:


### PR DESCRIPTION
We've noticed that on 500 errors there's some sensitive data logged to our Sentry. I guess user HTTP_COOKIES should not be made publically available as it has some major security risks. Maybe you will find this patch useful for securing Pulsar